### PR TITLE
Fix database crash on memory save.

### DIFF
--- a/app/src/main/java/nl/hogeschoolrotterdam/projectb/data/Database.java
+++ b/app/src/main/java/nl/hogeschoolrotterdam/projectb/data/Database.java
@@ -30,7 +30,7 @@ public class Database {
     }
 
     public String newId() {
-        return String.valueOf(memories.size());
+        return String.valueOf(System.currentTimeMillis());
     }
 
     @NonNull


### PR DESCRIPTION
Changes:
 * Fixed the crashing issue with the database


So, the problem was that the memory ID wasn't always unique. 

It wasn't unique because it used the size of all memories as a number for the id. 
But, when you delete a memory, the list get's smaller, and you'll get the same ID as before.

Now it just uses epoch unix time as an id. 
